### PR TITLE
Differentiate between hashtags and topics

### DIFF
--- a/api/twitteranalyser/twitteranalyser/tweetresource.py
+++ b/api/twitteranalyser/twitteranalyser/tweetresource.py
@@ -121,10 +121,15 @@ class Tweet(object):
                 # performed. If it has, get the ID of the already existing
                 # query, if not, insert a new row into the analysis_topic
                 # table and get its ID.
-                analysis_topic = self.tweet_topic_table.find_one(term=filter_term)
                 analysis_topic_id = 0
+                is_hashtag = False
+                if filter_term[0] == '#':
+                    is_hashtag = True
+                    analysis_topic = self.tweet_topic_table.find_one(term=filter_term[1:], is_hashtag=1)
+                else:
+                    analysis_topic = self.tweet_topic_table.find_one(term=filter_term, is_hashtag=0)
+
                 if analysis_topic is None:
-                    is_hashtag = False
                     if filter_term[0] == '#':
                         is_hashtag = True
                         filter_term = filter_term[1:]
@@ -150,7 +155,7 @@ class Tweet(object):
                 self.stream_listener.analysis_key_value = analysis_topic_id
 
                 self.stream.filter(track=[filter_term], languages=['en'], async=True)
-                resp.body = dumps({'topic_id': analysis_topic_id})
+                resp.body = dumps({'topic_id': analysis_topic_id, 'is_hashtag': is_hashtag})
                 resp.status = falcon.HTTP_OK
 
         # Only one stream can be running at once, so if another request comes

--- a/frontend/twitteranalyser/src/AppBundle/Controller/HomePageController.php
+++ b/frontend/twitteranalyser/src/AppBundle/Controller/HomePageController.php
@@ -65,11 +65,18 @@ class HomePageController extends Controller
 
         if ($result->isRateLimited()) {
             throw new TooManyRequestsHttpException($result->getTimeLeftOnStream(), 'Rate limited for '.$result->getTimeLeftOnStream().' seconds!');
-        } elseif ($result->isTopic()) {
+        } elseif ($result->isTopic() && !$result->isHashtag()) {
             $topic = $this->getDoctrine()->getRepository(AnalysisTopic::class)->find($result->getId());
 
             return $this->redirectToRoute(
                 'topic_results',
+                ['term' => $topic->getTerm()]
+            );
+        } elseif ($result->isHashtag()) {
+            $topic = $this->getDoctrine()->getRepository(AnalysisTopic::class)->find($result->getId());
+
+            return $this->redirectToRoute(
+                'hashtag_results',
                 ['term' => $topic->getTerm()]
             );
         } else {

--- a/frontend/twitteranalyser/src/AppBundle/Controller/ResultsController.php
+++ b/frontend/twitteranalyser/src/AppBundle/Controller/ResultsController.php
@@ -45,6 +45,27 @@ class ResultsController extends Controller
     }
 
     /**
+     * @Route("/hashtag/{term}", name="hashtag_results")
+     * @Template("default/results.html.twig")
+     *
+     * @param string $term
+     *
+     * @return array
+     */
+    public function hashtagResultsAction(string $term)
+    {
+        $resultsAnalyser = $this->get('app.results_analyser');
+        $results = $resultsAnalyser->getResultsForHashtag($term);
+
+        return [
+            'tweets' => $results->getTweets(),
+            'term' => $results->getTerm(),
+            'positiveTweets' => $results->getPositiveTweets(),
+            'negativeTweets' => $results->getNegativeTweets(),
+        ];
+    }
+
+    /**
      * @Route("/user/{term}", name="user_results")
      * @Template("default/results.html.twig")
      *

--- a/frontend/twitteranalyser/src/AppBundle/Entity/AnalysisTopic.php
+++ b/frontend/twitteranalyser/src/AppBundle/Entity/AnalysisTopic.php
@@ -39,6 +39,13 @@ class AnalysisTopic implements AnalysisEntityInterface
     protected $term;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(name="is_hashtag", type="boolean", nullable=false)
+     */
+    protected $hashtag;
+
+    /**
      * @var ArrayCollection
      *
      * @ORM\OneToMany(targetEntity="Tweet", mappedBy="analysisTopicId")
@@ -77,6 +84,14 @@ class AnalysisTopic implements AnalysisEntityInterface
     public function getTweets(): Collection
     {
         return $this->tweets;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHashtag(): bool
+    {
+        return $this->hashtag;
     }
 
     /**

--- a/frontend/twitteranalyser/src/AppBundle/Model/AnalysisObject.php
+++ b/frontend/twitteranalyser/src/AppBundle/Model/AnalysisObject.php
@@ -23,6 +23,11 @@ class AnalysisObject
     /**
      * @var bool
      */
+    private $hashtag;
+
+    /**
+     * @var bool
+     */
     private $rateLimited;
 
     /**
@@ -42,17 +47,20 @@ class AnalysisObject
      * @param int  $id
      * @param bool $rateLimited
      * @param int  $timeLeftOnStream
+     * @param bool $hashtag
      */
     private function __construct(
         bool $topic = false,
         int $id = null,
         bool $rateLimited = false,
-        int $timeLeftOnStream = null
+        int $timeLeftOnStream = null,
+        bool $hashtag = false
     ) {
         $this->topic = $topic;
         $this->id = $id;
         $this->rateLimited = $rateLimited;
         $this->timeLeftOnStream = $timeLeftOnStream;
+        $this->hashtag = $hashtag;
     }
 
     /**
@@ -73,6 +81,16 @@ class AnalysisObject
     public static function fromTopicResponse(int $id): self
     {
         return new self(true, $id, false, null);
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return AnalysisObject
+     */
+    public static function fromHashtagResponse(int $id): self
+    {
+        return new self(true, $id, false, null, true);
     }
 
     /**
@@ -123,5 +141,13 @@ class AnalysisObject
     public function getTimeLeftOnStream(): int
     {
         return $this->timeLeftOnStream;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHashtag(): bool
+    {
+        return $this->hashtag;
     }
 }

--- a/frontend/twitteranalyser/src/AppBundle/Service/AnalysisGetter.php
+++ b/frontend/twitteranalyser/src/AppBundle/Service/AnalysisGetter.php
@@ -24,6 +24,7 @@ class AnalysisGetter
 
     const USER_RESPONSE_BODY_KEY = 'user_id';
     const TOPIC_RESPONSE_BODY_KEY = 'topic_id';
+    const HASHTAG_RESPONSE_BODY_KEY = 'is_hashtag';
     const RATE_LIMITED_KEY = 'rate_limited';
     const TIME_LEFT_ON_STREAM_KEY = 'time_left_on_stream';
 
@@ -69,7 +70,11 @@ class AnalysisGetter
         if (array_key_exists(self::RATE_LIMITED_KEY, $responseBody)) {
             return AnalysisObject::fromRateLimitedResponse($responseBody[self::TIME_LEFT_ON_STREAM_KEY]);
         } elseif (array_key_exists(self::TOPIC_RESPONSE_BODY_KEY, $responseBody)) {
-            return AnalysisObject::fromTopicResponse($responseBody[self::TOPIC_RESPONSE_BODY_KEY]);
+            if ($responseBody[self::HASHTAG_RESPONSE_BODY_KEY] === true) {
+                return AnalysisObject::fromHashtagResponse($responseBody[self::TOPIC_RESPONSE_BODY_KEY]);
+            } else {
+                return AnalysisObject::fromTopicResponse($responseBody[self::TOPIC_RESPONSE_BODY_KEY]);
+            }
         } elseif (array_key_exists(self::USER_RESPONSE_BODY_KEY, $responseBody)) {
             return AnalysisObject::fromUserResponse($responseBody[self::USER_RESPONSE_BODY_KEY]);
         }

--- a/frontend/twitteranalyser/src/AppBundle/Service/ResultsAnalyser.php
+++ b/frontend/twitteranalyser/src/AppBundle/Service/ResultsAnalyser.php
@@ -82,7 +82,28 @@ class ResultsAnalyser
         /**
          * @var AnalysisTopic $topic
          */
-        $topic = $this->analysisTopicRepository->findOneBy(['term' => $topic]);
+        $topic = $this->analysisTopicRepository->findOneBy(['term' => $topic, 'hashtag' => 0]);
+        $positiveTweets = $this
+            ->tweetRepository
+            ->getNumberOfTweetsForTopicIdWithSentiment($topic->getId(), 'positive');
+        $negativeTweets = $this
+            ->tweetRepository
+            ->getNumberOfTweetsForTopicIdWithSentiment($topic->getId(), 'negative');
+
+        return new ResultsObject($topic->getTweets(), $topic, $positiveTweets, $negativeTweets);
+    }
+
+    /**
+     * @param string $topic
+     *
+     * @return ResultsObject
+     */
+    public function getResultsForHashtag(string $topic): ResultsObject
+    {
+        /**
+         * @var AnalysisTopic $topic
+         */
+        $topic = $this->analysisTopicRepository->findOneBy(['term' => $topic, 'hashtag' => 1]);
         $positiveTweets = $this
             ->tweetRepository
             ->getNumberOfTweetsForTopicIdWithSentiment($topic->getId(), 'positive');

--- a/frontend/twitteranalyser/tests/AppBundle/Service/AnalysisGetterTest.php
+++ b/frontend/twitteranalyser/tests/AppBundle/Service/AnalysisGetterTest.php
@@ -21,6 +21,7 @@ class AnalysisGetterTest extends \PHPUnit_Framework_TestCase
     private const TOPIC = 'topic';
     private const USER = 'user';
     private const BROKEN = 'broken';
+    private const HASHTAG = 'hashtag';
 
     /**
      * @param string $term
@@ -29,9 +30,9 @@ class AnalysisGetterTest extends \PHPUnit_Framework_TestCase
      * @param string $responseBody
      * @param string $type
      *
-     * @dataProvider analysisProviderRateLimited
+     * @dataProvider analysisProvider
      */
-    public function testStartAnalysisRateLimited(string $term, string $execTime, string $execNumber, string $responseBody, string $type)
+    public function testStartAnalysis(string $term, string $execTime, string $execNumber, string $responseBody, string $type)
     {
         $mockRequestReturnMap = [
             [AnalysisGetter::TERM_PARAM, null, $term],
@@ -86,11 +87,12 @@ class AnalysisGetterTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function analysisProviderRateLimited()
+    public function analysisProvider()
     {
         return [
             'rate_limited' => ['test', '60', '100', '{"rate_limited": true, "time_left_on_stream": 100}', self::RATE_LIMITED],
-            'topic' => ['test', '60', '100', '{"topic_id": 1}', self::TOPIC],
+            'topic' => ['test', '60', '100', '{"topic_id": 1, "is_hashtag": 0}', self::TOPIC],
+            'hashtag' => ['test', '60', '100', '{"topic_id": 1, "is_hashtag": 0}', self::HASHTAG],
             'user' => ['@test', '60', '100', '{"user_id": 1}', self::USER],
             'broken' => ['@test', '60', '100', '{"broken": 1}', self::BROKEN],
         ];

--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -1,8 +1,9 @@
 CREATE TABLE IF NOT EXISTS analysis_topic
 (
     id BIGINT PRIMARY KEY NOT NULL AUTO_INCREMENT,
-    term VARCHAR(300) NOT NULL UNIQUE,
-    is_hashtag BOOLEAN NOT NULL
+    term VARCHAR(300) NOT NULL,
+    is_hashtag BOOLEAN NOT NULL,
+    UNIQUE KEY term_is_hashtag (term, is_hashtag)
 ) CHARACTER SET utf8mb4;
 
 CREATE TABLE IF NOT EXISTS analysis_user


### PR DESCRIPTION
It's possible for a user to search for a term as a hashtag, and then
search for the term as a keyword.

This commit makes the app differentiate between these cases, and adds a
composite unique constraint on `term` and `is_hashtag` to the
`analysis_topic` table.

Fixes #44 